### PR TITLE
Makes so that you can run `test/index.html`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "expect.js": "~0.2.0",
     "benchmark": "~1.0.0",
     "microtime": "~0.4.0",
-    "source-map-support": "~0.2.1"
+    "source-map-support": "~0.2.1",
+    "mocha": "~1.14.0"
   },
   "keywords": [
     "vm",

--- a/test/index.html
+++ b/test/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 <div id="mocha">
-  <script src="http://192.168.56.50:35729/livereload.js"></script>
+  <script src="http://localhost:35729/livereload.js"></script>
   <script src="../node_modules/expect.js/expect.js"></script>
   <script src="../node_modules/mocha/mocha.js"></script>
   <script>


### PR DESCRIPTION
Live reload was pointing to local network IP and `mocha` wasn't in dev dependencies.
